### PR TITLE
5/12: add Calendar using react-calendar to Calendar Page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
         "react": "^18.2.0",
+        "react-calendar": "^4.2.1",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.11.1",
         "react-scripts": "5.0.1",
@@ -4150,6 +4151,19 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="
     },
+    "node_modules/@types/lodash": {
+      "version": "4.14.194",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.194.tgz",
+      "integrity": "sha512-r22s9tAS7imvBt2lyHC9B8AGwWnXaYb1tY09oyLkXDs4vArpYJzw09nj8MLx5VfciBPGIb+ZwG0ssYnEPJxn/g=="
+    },
+    "node_modules/@types/lodash.memoize": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash.memoize/-/lodash.memoize-4.1.7.tgz",
+      "integrity": "sha512-lGN7WeO4vO6sICVpf041Q7BX/9k1Y24Zo3FY0aUezr1QlKznpjzsDk3T3wvH8ofYzoK0QupN9TWcFAFZlyPwQQ==",
+      "dependencies": {
+        "@types/lodash": "*"
+      }
+    },
     "node_modules/@types/mime": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
@@ -4651,6 +4665,14 @@
       "dependencies": {
         "@webassemblyjs/ast": "1.11.5",
         "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@wojtekmaj/date-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@wojtekmaj/date-utils/-/date-utils-1.1.3.tgz",
+      "integrity": "sha512-rHrDuTl1cx5LYo8F4K4HVauVjwzx4LwrKfEk4br4fj4nK8JjJZ8IG6a6pBHkYmPLBQHCOEDwstb0WNXMGsmdOw==",
+      "funding": {
+        "url": "https://github.com/wojtekmaj/date-utils?sponsor=1"
       }
     },
     "node_modules/@xtuc/ieee754": {
@@ -5784,6 +5806,14 @@
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/co": {
@@ -8459,6 +8489,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-user-locale": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/get-user-locale/-/get-user-locale-2.2.1.tgz",
+      "integrity": "sha512-3814zipTZ2MvczOcppEXB3jXu+0HWwj5WmPI6//SeCnUIUaRXu7W4S54eQZTEPadlMZefE+jAlPOn+zY3tD4Qw==",
+      "dependencies": {
+        "@types/lodash.memoize": "^4.1.7",
+        "lodash.memoize": "^4.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/wojtekmaj/get-user-locale?sponsor=1"
       }
     },
     "node_modules/glob": {
@@ -14217,6 +14259,25 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/react-calendar": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/react-calendar/-/react-calendar-4.2.1.tgz",
+      "integrity": "sha512-T5oKXD+KLy/g6bmJJkZ7E9wj0iRMesWMZcrC7q2kI6ybOsu9NlPQx8uXJzG4A4C3Sh5Xi0deznyzWIVsUpF8tA==",
+      "dependencies": {
+        "@types/react": "*",
+        "@wojtekmaj/date-utils": "^1.1.3",
+        "clsx": "^1.2.1",
+        "get-user-locale": "^2.2.1",
+        "prop-types": "^15.6.0"
+      },
+      "funding": {
+        "url": "https://github.com/wojtekmaj/react-calendar?sponsor=1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-dev-utils": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
     "react": "^18.2.0",
+    "react-calendar": "^4.2.1",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.11.1",
     "react-scripts": "5.0.1",

--- a/src/pages/CalendarPage/Calendar.css
+++ b/src/pages/CalendarPage/Calendar.css
@@ -1,0 +1,159 @@
+.title {
+    margin-left: 10%;
+    text-align: center;
+    font-size: 3vw;
+}
+
+.select-date {
+    margin-left: 10%;
+    text-align: center;
+    font-size: 1.5vw;
+    margin-top: 2%;
+    margin-bottom: 2%;
+}
+
+.react-calendar {
+  width: 80%;
+  height: 80%;
+  margin-left: 15%;
+  margin-right: 5%;
+  background: white;
+  border: 1px solid #a0a096;
+  font-family: Arial, Helvetica, sans-serif;
+  line-height: 1.125em;
+}
+
+.react-calendar--doubleView {
+  width: 700px;
+}
+
+.react-calendar--doubleView .react-calendar__viewContainer {
+  display: flex;
+  margin: -0.5em;
+}
+
+.react-calendar--doubleView .react-calendar__viewContainer > * {
+  width: 50%;
+  margin: 0.5em;
+}
+
+.react-calendar,
+.react-calendar *,
+.react-calendar *:before,
+.react-calendar *:after {
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+}
+
+.react-calendar button {
+  margin: 0;
+  border: 0;
+  outline: none;
+}
+
+.react-calendar button:enabled:hover {
+  cursor: pointer;
+}
+
+.react-calendar__navigation {
+  display: flex;
+  height: 44px;
+  margin-bottom: 1em;
+}
+
+.react-calendar__navigation button {
+  min-width: 44px;
+  background: none;
+}
+
+.react-calendar__navigation button:disabled {
+  background-color: #f0f0f0;
+}
+
+.react-calendar__navigation button:enabled:hover,
+.react-calendar__navigation button:enabled:focus {
+  background-color: #e6e6e6;
+}
+
+.react-calendar__month-view__weekdays {
+  text-align: center;
+  text-transform: uppercase;
+  font-weight: bold;
+  font-size: 0.75em;
+}
+
+.react-calendar__month-view__weekdays__weekday {
+  padding: 0.5em;
+}
+
+.react-calendar__month-view__weekNumbers .react-calendar__tile {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75em;
+  font-weight: bold;
+}
+
+.react-calendar__month-view__days__day--weekend {
+  color: #d10000;
+}
+
+.react-calendar__month-view__days__day--neighboringMonth {
+  color: #757575;
+}
+
+.react-calendar__year-view .react-calendar__tile,
+.react-calendar__decade-view .react-calendar__tile,
+.react-calendar__century-view .react-calendar__tile {
+  padding: 2em 0.5em;
+}
+
+.react-calendar__tile {
+  max-width: 100%;
+  padding: 10px 6.6667px;
+  background: none;
+  text-align: center;
+  line-height: 16px;
+}
+
+.react-calendar__tile:disabled {
+  background-color: #f0f0f0;
+}
+
+.react-calendar__tile:enabled:hover,
+.react-calendar__tile:enabled:focus {
+  background-color: #e6e6e6;
+}
+
+.react-calendar__tile--now {
+  background: #ffff76;
+}
+
+.react-calendar__tile--now:enabled:hover,
+.react-calendar__tile--now:enabled:focus {
+  background: #ffffa9;
+}
+
+.react-calendar__tile--hasActive {
+  background: #76baff;
+}
+
+.react-calendar__tile--hasActive:enabled:hover,
+.react-calendar__tile--hasActive:enabled:focus {
+  background: #a9d4ff;
+}
+
+.react-calendar__tile--active {
+  background: #006edc;
+  color: white;
+}
+
+.react-calendar__tile--active:enabled:hover,
+.react-calendar__tile--active:enabled:focus {
+  background: #1087ff;
+}
+
+.react-calendar--selectRange .react-calendar__tile--hover {
+  background-color: #e6e6e6;
+}

--- a/src/pages/CalendarPage/Calendar.js
+++ b/src/pages/CalendarPage/Calendar.js
@@ -1,11 +1,27 @@
-import Calendar from '../../components/Calendar/Calendar.js'
+import Calendar from 'react-calendar'
+import './Calendar.css'
+import {useState} from 'react'
 
 function CalendarPage(){
+    const today = new Date();
+    const [date, setDate] = useState(today);
+           //the Date object has
+           //getDate() to get the day of the month
+           //getMonth() to get month of year from 0-11, 0=January, 11=December
+           //getFullYear() to get year in 4 digit format
     return(
-           <>
-        <h1>CalendarPage</h1>
-           <Calendar />
-           </>
+        <>
+           <h1 className="title">CalendarPage</h1>
+           <div className="calendar">
+                <Calendar
+                    view="month"
+                    showNeighboringMonth={false}
+                    onChange={setDate}
+                    value={date}
+                />
+           </div>
+           <p className="select-date">{date.toDateString()}</p>
+        </>
     )
 };
 


### PR DESCRIPTION
Use 'npm install react-calendar' to obtain the module for react-calendar and import Calendar from 'react-calendar' first before using modify attributes in the Calendar.css inside CalendarPage directory (modify a copy of the Calendar.css file inside node_modules, overriding original classes) modified the page title to stand in center between border of screen and border of sidebar Selecting dates on a calendar currently enables display of that date below in centered text. -Placeholder/Subject to change into a list of events arranged chronologically.