### PR TITLE
6/3: Events tab modified to hold past and upcoming events

### DIFF
--- a/src/components/dashboard.js
+++ b/src/components/dashboard.js
@@ -44,8 +44,6 @@ export default function Dashboard(){
                     <Link to="/CalendarPage" className="nav-link"><button className="nav-button">CalendarPage</button></Link>
                     <Link to="/Friends" className="nav-link"><button className="nav-button"> Friends</button></Link>
 	            <Link to="/Events" className="nav-link"><button className="nav-button"> Events</button></Link>
-                    <Link to="/PastEvents" className="nav-link"><button className="nav-button">Past Events</button></Link>
-	            <Link to="/FutureEvents" className="nav-link"><button className="nav-button">Upcoming Events</button></Link>
                 </nav>
                 <Routes>
                     <Route path="/CalendarPage" element={<CalendarPage />} />

--- a/src/pages/Events/Events.js
+++ b/src/pages/Events/Events.js
@@ -1,6 +1,9 @@
 import React, { useEffect, useState } from 'react';
 import { auth, db } from '../../utils/firebase'; // Update the path to your Firebase configuration file
 import { ref, push, set, onValue } from 'firebase/database';
+import { Route, Routes, Link } from 'react-router-dom';
+import PastEvents from "./PastEvents";
+import FutureEvents from "./UpcomingEvents";
 
 function Events() {
   const [events, setEvents] = useState([]);
@@ -53,29 +56,17 @@ function Events() {
   
   return (
     <div>
-      <h2>Events page</h2>
-      <div>
-        {events.map((event) => (
-          <div key={event.id}>
-            <h3>{event.name}</h3>
-            <p>Date: {event.date}</p>
-            <p>Time: {event.time}</p>
-          </div>
-        ))}
-      </div>
-      <div>
-        <label>Event Name:</label>
-        <input type="text" value={eventName} onChange={(e) => setEventName(e.target.value)} />
-      </div>
-      <div>
-        <label>Event Date:</label>
-        <input type="text" value={eventDate} onChange={(e) => setEventDate(e.target.value)} />
-      </div>
-      <div>
-        <label>Event Time:</label>
-        <input type="text" value={eventTime} onChange={(e) => setEventTime(e.target.value)} />
-      </div>
-      <button onClick={handleCreateEvent}>Create Event</button>
+	<h2>Events page</h2>
+	<div>
+            <nav className="navbar">
+                <Link to="/PastEvents" className="nav-link"><button className="nav-button">Past Events</button></Link>
+	        <Link to="/FutureEvents" className="nav-link"><button className="nav-button">Upcoming Events</button></Link>
+            </nav>
+            <Routes>
+                <Route path="/PastEvents" element={<PastEvents/>} />
+	        <Route path="/FutureEvents" element={<FutureEvents/>} />
+            </Routes>  
+        </div>
     </div>
   );
 }

--- a/src/pages/Events/PastEvents.js
+++ b/src/pages/Events/PastEvents.js
@@ -1,9 +1,22 @@
 import React from "react";
 import Events from  "./Planning.js";
+import FutureEvents from "./UpcomingEvents.js"
+import { Route, Routes, Link } from 'react-router-dom';
 
 export default function PastEvents()
 {
     return (
-	<Events lookForward={false} />
+	<>
+	    <div>
+		<nav className="navbar">
+	            <Link to="/FutureEvents" className="nav-link"><button className="nav-button">Upcoming Events</button></Link>
+		</nav>
+		<Routes>
+	            <Route path="/FutureEvents" element={<FutureEvents/>} />
+		</Routes>  
+            </div>
+	    <Events lookForward={false} />
+	</>
+	
     );
 }

--- a/src/pages/Events/UpcomingEvents.js
+++ b/src/pages/Events/UpcomingEvents.js
@@ -1,9 +1,21 @@
 import React from "react";
 import Events from "./Planning.js";
+import PastEvents from "./PastEvents.js"
+import { Route, Routes, Link } from 'react-router-dom';
 
 export default function FutureEvents()
 {
     return (
-	<Events lookForward={true} />
+	<>
+	    <div>
+		<nav className="navbar">
+	            <Link to="/PastEvents" className="nav-link"><button className="nav-button">Past Events</button></Link>
+		</nav>
+		<Routes>
+	            <Route path="/PastEvents" element={<PastEvents/>} />
+		</Routes>  
+            </div>
+	    <Events lookForward={true} />
+	</>
     );
 }


### PR DESCRIPTION
Original split Past and Upcoming events tabs combined back into the Events tab The new Events function (manual addition) removed, adding events function is reserved solely for the Calendar tab Events tab now include 2 buttons to move to the Past Events and Upcoming Events page. The two pages can move between each other.